### PR TITLE
Add missing chain method to interface

### DIFF
--- a/Bus/Dispatcher.php
+++ b/Bus/Dispatcher.php
@@ -5,6 +5,14 @@ namespace Illuminate\Contracts\Bus;
 interface Dispatcher
 {
     /**
+     * Create a new chain of queueable jobs.
+     *
+     * @param  \Illuminate\Support\Collection|array|null  $jobs
+     * @return mixed
+     */
+    public function chain($jobs = null);
+    
+    /**
      * Dispatch a command to its appropriate handler.
      *
      * @param  mixed  $command


### PR DESCRIPTION
Maybe there is a reason, but I was missing the `chain` method in the Dispatcher interface.